### PR TITLE
error: use of undeclared identifier 'android_set_rt_ioprio'

### DIFF
--- a/libhwcomposer/hwc_vsync.cpp
+++ b/libhwcomposer/hwc_vsync.cpp
@@ -19,7 +19,6 @@
  */
 
 #include <cutils/properties.h>
-#include <cutils/iosched_policy.h>
 #include <utils/Log.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
@@ -129,7 +128,6 @@ static void *vsync_loop(void *param)
     prctl(PR_SET_NAME, (unsigned long) &thread_name, 0, 0, 0);
     setpriority(PRIO_PROCESS, 0, HAL_PRIORITY_URGENT_DISPLAY +
                 android::PRIORITY_MORE_FAVORABLE);
-    android_set_rt_ioprio(0, 1);
 
     char vdata[MAX_DATA];
     //Number of physical displays


### PR DESCRIPTION
please change this else you will get a build error:

hardware/qcom/display-caf/msm8952/libhwcomposer/hwc_vsync.cpp:132:5: error: use of undeclared identifier 'android_set_rt_ioprio'
    android_set_rt_ioprio(0, 1);
    ^
1 error generated.